### PR TITLE
chore: pin the Windows unit tests to Windows 2022.

### DIFF
--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
     name: PR unit tests (windows)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Something about Windows 2025 broke `TestNewEnvClient/ssh`. Certainly we need to figure it out but... not now.
